### PR TITLE
Stream per-ping results and add live terminal timelines with slow-threshold

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 
 import argparse
+import queue
+import shutil
+from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 
-from scapy.all import IP, ICMP, sr
+from scapy.all import ICMP, IP, sr
 
 # A handler for command line options
 def handle_options():
@@ -11,6 +14,7 @@ def handle_options():
     parser = argparse.ArgumentParser(description="MultiPing - Perform ICMP ping operations to multiple hosts concurrently")
     parser.add_argument('-t', '--timeout', type=int, default=1, help='Timeout in seconds for each ping (default: 1)')
     parser.add_argument('-c', '--count', type=int, default=4, help='Number of ping attempts per host (default: 4)')
+    parser.add_argument('--slow-threshold', type=float, default=0.5, help='Threshold in seconds for slow ping (default: 0.5)')
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output, showing detailed ping results')
     parser.add_argument('-f', '--input', type=str, help='Input file containing list of hosts (one per line)', required=False)
     parser.add_argument('hosts', nargs='*', help='Hosts to ping (IP addresses or hostnames)')
@@ -41,7 +45,7 @@ def read_input_file(input_file):
     return host_list
 
 # Ping a single host
-def ping_host(host, timeout, count, verbose):
+def ping_host(host, timeout, count, slow_threshold, verbose):
     """
     Ping a single host with the specified parameters.
     
@@ -51,14 +55,12 @@ def ping_host(host, timeout, count, verbose):
         count: Number of ping attempts
         verbose: Whether to show detailed output
     
-    Returns:
-        A tuple of (host, success_count, total_count)
+    Yields:
+        A dict with host, sequence, status, and rtt
     """
-    success_count = 0
-    
     if verbose:
         print(f"\n--- Pinging {host} ---")
-    
+
     for i in range(count):
         try:
             # Create ICMP packet
@@ -66,24 +68,81 @@ def ping_host(host, timeout, count, verbose):
             
             # Send ICMP packet
             ans, unans = sr(icmp, timeout=timeout, verbose=0)
-            
+
             if ans:
-                success_count += 1
+                sent, received = ans[0]
+                rtt = received.time - sent.time
+                status = "slow" if rtt >= slow_threshold else "success"
                 if verbose:
-                    print(f"Reply from {host}: seq={i+1}")
+                    print(f"Reply from {host}: seq={i+1} rtt={rtt:.3f}s")
                     for r in ans:
                         r[1].show()
+                yield {"host": host, "sequence": i + 1, "status": status, "rtt": rtt}
             else:
                 if verbose:
                     print(f"No reply from {host}: seq={i+1}")
+                yield {"host": host, "sequence": i + 1, "status": "fail", "rtt": None}
         except OSError as e:
             if verbose:
                 print(f"Network error pinging {host}: {e}")
+            yield {"host": host, "sequence": i + 1, "status": "fail", "rtt": None}
         except Exception as e:
             if verbose:
                 print(f"Error pinging {host}: {e}")
-    
-    return (host, success_count, count)
+            yield {"host": host, "sequence": i + 1, "status": "fail", "rtt": None}
+
+def compute_layout(hosts, header_lines=2):
+    term_size = shutil.get_terminal_size(fallback=(80, 24))
+    width = term_size.columns
+    height = term_size.lines
+
+    max_host_len = max((len(host) for host in hosts), default=4)
+    label_width = min(max_host_len, max(10, width // 3))
+    timeline_width = max(1, width - label_width - 3)
+    visible_hosts = max(1, height - header_lines)
+
+    return width, label_width, timeline_width, visible_hosts
+
+
+def format_status_line(host, timeline, label_width):
+    return f"{host:<{label_width}} | {timeline}"
+
+
+def resize_buffers(buffers, timeline_width, symbols):
+    for host, host_buffers in buffers.items():
+        if host_buffers["timeline"].maxlen != timeline_width:
+            host_buffers["timeline"] = deque(host_buffers["timeline"], maxlen=timeline_width)
+        for status in symbols:
+            if host_buffers["categories"][status].maxlen != timeline_width:
+                host_buffers["categories"][status] = deque(
+                    host_buffers["categories"][status], maxlen=timeline_width
+                )
+
+
+def render_display(hosts, buffers, stats, symbols, header_lines=2):
+    width, label_width, timeline_width, visible_hosts = compute_layout(hosts, header_lines)
+    truncated_hosts = hosts[:visible_hosts]
+
+    resize_buffers(buffers, timeline_width, symbols)
+
+    lines = []
+    lines.append("MultiPing - Live results")
+    lines.append("".join("-" for _ in range(width)))
+    for host in truncated_hosts:
+        timeline = "".join(buffers[host]["timeline"]).rjust(timeline_width)
+        lines.append(format_status_line(host, timeline, label_width))
+
+    if len(hosts) > len(truncated_hosts):
+        remaining = len(hosts) - len(truncated_hosts)
+        lines.append(f"... ({remaining} host(s) not shown)")
+
+    print("\x1b[2J\x1b[H" + "\n".join(lines), end="", flush=True)
+
+
+def worker_ping(host, timeout, count, slow_threshold, verbose, result_queue):
+    for result in ping_host(host, timeout, count, slow_threshold, verbose):
+        result_queue.put(result)
+    result_queue.put({"host": host, "status": "done"})
 
 def main(args):
 
@@ -109,27 +168,68 @@ def main(args):
         print("Error: No hosts specified. Provide hosts as arguments or use -f/--input option.")
         return
     
-    print(f"MultiPing - Pinging {len(all_hosts)} host(s) with timeout={args.timeout}s, count={args.count}")
-    print("-" * 60)
-    
-    # Ping all hosts concurrently using ThreadPoolExecutor
+    symbols = {"success": ".", "fail": "x", "slow": "!"}
+    _, _, timeline_width, _ = compute_layout(all_hosts)
+    buffers = {
+        host: {
+            "timeline": deque(maxlen=timeline_width),
+            "categories": {status: deque(maxlen=timeline_width) for status in symbols},
+        }
+        for host in all_hosts
+    }
+    stats = {
+        host: {"success": 0, "fail": 0, "slow": 0, "total": 0}
+        for host in all_hosts
+    }
+    result_queue = queue.Queue()
+
+    print(
+        f"MultiPing - Pinging {len(all_hosts)} host(s) with timeout={args.timeout}s, "
+        f"count={args.count}, slow-threshold={args.slow_threshold}s"
+    )
+
     with ThreadPoolExecutor(max_workers=min(len(all_hosts), 10)) as executor:
-        futures = [
-            executor.submit(ping_host, host, args.timeout, args.count, args.verbose)
-            for host in all_hosts
-        ]
-        
-        # Collect results
-        results = [future.result() for future in futures]
-    
-    # Display summary
+        for host in all_hosts:
+            executor.submit(
+                worker_ping,
+                host,
+                args.timeout,
+                args.count,
+                args.slow_threshold,
+                args.verbose,
+                result_queue,
+            )
+
+        completed_hosts = 0
+        render_display(all_hosts, buffers, stats, symbols)
+        while completed_hosts < len(all_hosts):
+            result = result_queue.get()
+            host = result["host"]
+            if result.get("status") == "done":
+                completed_hosts += 1
+                continue
+
+            status = result["status"]
+            buffers[host]["timeline"].append(symbols[status])
+            buffers[host]["categories"][status].append(result["sequence"])
+            stats[host][status] += 1
+            stats[host]["total"] += 1
+            render_display(all_hosts, buffers, stats, symbols)
+
     print("\n" + "=" * 60)
     print("SUMMARY")
     print("=" * 60)
-    for host, success, total in results:
+    for host in all_hosts:
+        success = stats[host]["success"]
+        slow = stats[host]["slow"]
+        fail = stats[host]["fail"]
+        total = stats[host]["total"]
         percentage = (success / total * 100) if total > 0 else 0
         status = "OK" if success > 0 else "FAILED"
-        print(f"{host:30} {success}/{total} replies ({percentage:.1f}%) [{status}]")
+        print(
+            f"{host:30} {success}/{total} replies, {slow} slow, {fail} failed "
+            f"({percentage:.1f}%) [{status}]"
+        )
 
 if __name__ == "__main__":
     # Handle command line options


### PR DESCRIPTION
### Motivation
- Provide per-attempt ping feedback so the main loop can render live updates instead of waiting for host completion.
- Keep a recent history per host to display a compact timeline and categorize events (success/fail/slow).
- Allow users to mark high-latency responses via a configurable slow threshold (`--slow-threshold`).
- Render a fixed-width, one-host-per-line timeline in the terminal with automatic layout that adapts to terminal size.

### Description
- Changed `ping_host` to yield per-attempt result dicts (`host`, `sequence`, `status`, `rtt`) and added `worker_ping` to stream those into a `queue.Queue` for consumption.
- Replaced bulk future-collection with a queue-driven `ThreadPoolExecutor` model that updates per-host ring buffers stored as `deque` structures and per-category buffers for tracking.
- Added layout helpers `compute_layout`, `resize_buffers`, and `render_display` which use `shutil.get_terminal_size`, ANSI sequences for screen redraw, and a timeline width that adapts to terminal columns.
- Added CLI option `--slow-threshold` and a `symbols` mapping (`.`/`x`/`!`) to represent success/failure/slow in the live timelines and the final summary.

### Testing
- No automated tests were executed for this change.
- Manual validation was performed by running the script interactively (not part of automated test suite).
- There are no new unit tests in this patch.
- Existing test suite was not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696335f6bd448330b4c18da02d84a1b1)