### PR TITLE
Add configurable summary panel layout and decoupled summary rendering

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,13 @@ def handle_options():
     parser.add_argument('--slow-threshold', type=float, default=0.5, help='Threshold in seconds for slow ping (default: 0.5)')
     parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output, showing detailed ping results')
     parser.add_argument('-f', '--input', type=str, help='Input file containing list of hosts (one per line)', required=False)
+    parser.add_argument(
+        '--panel-position',
+        type=str,
+        default='right',
+        choices=['right', 'left', 'top', 'bottom', 'none'],
+        help='Summary panel position (right|left|top|bottom|none)',
+    )
     parser.add_argument('hosts', nargs='*', help='Hosts to ping (IP addresses or hostnames)')
 
     args = parser.parse_args()
@@ -91,17 +98,46 @@ def ping_host(host, timeout, count, slow_threshold, verbose):
                 print(f"Error pinging {host}: {e}")
             yield {"host": host, "sequence": i + 1, "status": "fail", "rtt": None}
 
-def compute_layout(hosts, header_lines=2):
-    term_size = shutil.get_terminal_size(fallback=(80, 24))
-    width = term_size.columns
-    height = term_size.lines
-
+def compute_main_layout(hosts, width, height, header_lines=2):
     max_host_len = max((len(host) for host in hosts), default=4)
     label_width = min(max_host_len, max(10, width // 3))
     timeline_width = max(1, width - label_width - 3)
     visible_hosts = max(1, height - header_lines)
 
     return width, label_width, timeline_width, visible_hosts
+
+
+def compute_panel_sizes(
+    term_width,
+    term_height,
+    panel_position,
+    min_panel_width=30,
+    min_panel_height=5,
+    min_main_width=20,
+    min_main_height=5,
+    gap=1,
+):
+    if panel_position == "none":
+        return term_width, term_height, 0, 0, "none"
+
+    if term_width < min_main_width or term_height < min_main_height:
+        return term_width, term_height, 0, 0, "none"
+
+    if panel_position in ("left", "right"):
+        summary_width = max(min_panel_width, term_width // 4)
+        main_width = term_width - summary_width - gap
+        if main_width < min_main_width or summary_width < min_panel_width:
+            return term_width, term_height, 0, 0, "none"
+        return main_width, term_height, summary_width, term_height, panel_position
+
+    if panel_position in ("top", "bottom"):
+        summary_height = max(min_panel_height, term_height // 4)
+        main_height = term_height - summary_height - gap
+        if main_height < min_main_height or summary_height < min_panel_height:
+            return term_width, term_height, 0, 0, "none"
+        return term_width, main_height, term_width, summary_height, panel_position
+
+    return term_width, term_height, 0, 0, "none"
 
 
 def format_status_line(host, timeline, label_width):
@@ -119,8 +155,88 @@ def resize_buffers(buffers, timeline_width, symbols):
                 )
 
 
-def render_display(hosts, buffers, stats, symbols, header_lines=2):
-    width, label_width, timeline_width, visible_hosts = compute_layout(hosts, header_lines)
+def pad_lines(lines, width, height):
+    padded = [line[:width].ljust(width) for line in lines[:height]]
+    while len(padded) < height:
+        padded.append("".ljust(width))
+    return padded
+
+
+def compute_summary_data(hosts, buffers, stats, symbols):
+    summary = []
+    success_symbols = {symbols["success"], symbols["slow"]}
+    for host in hosts:
+        total = stats[host]["total"]
+        success = stats[host]["success"] + stats[host]["slow"]
+        fail = stats[host]["fail"]
+        success_rate = (success / total * 100) if total > 0 else 0.0
+        loss_rate = (fail / total * 100) if total > 0 else 0.0
+        timeline = list(buffers[host]["timeline"])
+        streak_type = None
+        streak_length = 0
+        if timeline:
+            last = timeline[-1]
+            if last in success_symbols:
+                streak_type = "success"
+                for symbol in reversed(timeline):
+                    if symbol in success_symbols:
+                        streak_length += 1
+                    else:
+                        break
+            elif last == symbols["fail"]:
+                streak_type = "fail"
+                for symbol in reversed(timeline):
+                    if symbol == symbols["fail"]:
+                        streak_length += 1
+                    else:
+                        break
+        avg_rtt_ms = None
+        if stats[host]["rtt_count"] > 0:
+            avg_rtt_ms = stats[host]["rtt_sum"] / stats[host]["rtt_count"] * 1000
+        summary.append(
+            {
+                "host": host,
+                "success_rate": success_rate,
+                "loss_rate": loss_rate,
+                "streak_type": streak_type,
+                "streak_length": streak_length,
+                "avg_rtt_ms": avg_rtt_ms,
+            }
+        )
+    return summary
+
+
+def render_summary_view(summary_data, width, height):
+    if width <= 0 or height <= 0:
+        return []
+
+    lines = ["Summary", "-" * width]
+    for entry in summary_data:
+        streak_label = "-"
+        if entry["streak_type"] == "fail":
+            streak_label = f"F{entry['streak_length']}"
+        elif entry["streak_type"] == "success":
+            streak_label = f"S{entry['streak_length']}"
+        line = (
+            f"{entry['host']}: ok {entry['success_rate']:.1f}% "
+            f"loss {entry['loss_rate']:.1f}% streak {streak_label}"
+        )
+        lines.append(line)
+        if entry["avg_rtt_ms"] is not None:
+            lines.append(f"  avg rtt {entry['avg_rtt_ms']:.1f} ms")
+        else:
+            lines.append("  avg rtt n/a")
+
+    return pad_lines(lines, width, height)
+
+
+def render_main_view(hosts, buffers, symbols, width, height, header_lines=2):
+    if width <= 0 or height <= 0:
+        return []
+
+    width, label_width, timeline_width, visible_hosts = compute_main_layout(
+        hosts, width, height, header_lines
+    )
     truncated_hosts = hosts[:visible_hosts]
 
     resize_buffers(buffers, timeline_width, symbols)
@@ -132,11 +248,42 @@ def render_display(hosts, buffers, stats, symbols, header_lines=2):
         timeline = "".join(buffers[host]["timeline"]).rjust(timeline_width)
         lines.append(format_status_line(host, timeline, label_width))
 
-    if len(hosts) > len(truncated_hosts):
+    if len(hosts) > len(truncated_hosts) and len(lines) < height:
         remaining = len(hosts) - len(truncated_hosts)
         lines.append(f"... ({remaining} host(s) not shown)")
 
-    print("\x1b[2J\x1b[H" + "\n".join(lines), end="", flush=True)
+    return pad_lines(lines, width, height)
+
+
+def render_display(hosts, buffers, stats, symbols, panel_position, header_lines=2):
+    term_size = shutil.get_terminal_size(fallback=(80, 24))
+    term_width = term_size.columns
+    term_height = term_size.lines
+
+    main_width, main_height, summary_width, summary_height, resolved_position = compute_panel_sizes(
+        term_width, term_height, panel_position
+    )
+    summary_data = compute_summary_data(hosts, buffers, stats, symbols)
+
+    main_lines = render_main_view(hosts, buffers, symbols, main_width, main_height, header_lines)
+    summary_lines = render_summary_view(summary_data, summary_width, summary_height)
+
+    gap = " "
+    combined_lines = []
+    if resolved_position in ("left", "right"):
+        for main_line, summary_line in zip(main_lines, summary_lines):
+            if resolved_position == "left":
+                combined_lines.append(f"{summary_line}{gap}{main_line}")
+            else:
+                combined_lines.append(f"{main_line}{gap}{summary_line}")
+    elif resolved_position == "top":
+        combined_lines = summary_lines + [""] + main_lines
+    elif resolved_position == "bottom":
+        combined_lines = main_lines + [""] + summary_lines
+    else:
+        combined_lines = main_lines
+
+    print("\x1b[2J\x1b[H" + "\n".join(combined_lines), end="", flush=True)
 
 
 def worker_ping(host, timeout, count, slow_threshold, verbose, result_queue):
@@ -169,7 +316,8 @@ def main(args):
         return
     
     symbols = {"success": ".", "fail": "x", "slow": "!"}
-    _, _, timeline_width, _ = compute_layout(all_hosts)
+    term_size = shutil.get_terminal_size(fallback=(80, 24))
+    _, _, timeline_width, _ = compute_main_layout(all_hosts, term_size.columns, term_size.lines)
     buffers = {
         host: {
             "timeline": deque(maxlen=timeline_width),
@@ -178,7 +326,7 @@ def main(args):
         for host in all_hosts
     }
     stats = {
-        host: {"success": 0, "fail": 0, "slow": 0, "total": 0}
+        host: {"success": 0, "fail": 0, "slow": 0, "total": 0, "rtt_sum": 0.0, "rtt_count": 0}
         for host in all_hosts
     }
     result_queue = queue.Queue()
@@ -201,7 +349,7 @@ def main(args):
             )
 
         completed_hosts = 0
-        render_display(all_hosts, buffers, stats, symbols)
+        render_display(all_hosts, buffers, stats, symbols, args.panel_position)
         while completed_hosts < len(all_hosts):
             result = result_queue.get()
             host = result["host"]
@@ -214,7 +362,10 @@ def main(args):
             buffers[host]["categories"][status].append(result["sequence"])
             stats[host][status] += 1
             stats[host]["total"] += 1
-            render_display(all_hosts, buffers, stats, symbols)
+            if result.get("rtt") is not None:
+                stats[host]["rtt_sum"] += result["rtt"]
+                stats[host]["rtt_count"] += 1
+            render_display(all_hosts, buffers, stats, symbols, args.panel_position)
 
     print("\n" + "=" * 60)
     print("SUMMARY")


### PR DESCRIPTION
### Motivation
- Add a configurable summary/panel layout so users can position a concise summary next to the main timeline using `--panel-position`.
- Make summary computation independent of the main view so aggregate metrics can be rendered separately and prioritized (loss/success rates, streaks).
- Use terminal size from `shutil.get_terminal_size` to split main and summary areas and automatically fall back when space is insufficient.
- Track minimal RTT aggregates to show a compact average RTT in the summary while keeping timeline rendering focused on recent symbols.

### Description
- Added a new CLI option `--panel-position` with choices `right|left|top|bottom|none` and plumbed it into rendering.
- Introduced `compute_panel_sizes` and `compute_main_layout` to calculate main/summary dimensions and implement automatic fallback to `none` when the terminal is too small.
- Extracted summary logic into `compute_summary_data` and `render_summary_view`, and split the previous monolithic renderer into `render_main_view` + `render_summary_view` with a new `render_display` combining them.
- Extended `stats` to track `rtt_sum`/`rtt_count` and updated live updates to accumulate RTTs for concise average RTT reporting.

### Testing
- No automated tests were run as part of this change.
- The change was implemented and formatted in `main.py` and validated via local static inspection only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69633c2bc374833096e49180cb5e092b)