### PR TITLE
Use ping_helper for ICMP pings by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MultiPing is an interactive, terminal-based ICMP monitor that pings many hosts i
 > 日本語版 README: [README.ja.md](README.ja.md)
 
 ## Features
-- Concurrent ICMP ping to multiple hosts (Scapy-based).
+- Concurrent ICMP ping to multiple hosts (capability-based helper binary).
 - Live timeline or sparkline visualization with success/slow/fail markers.
 - Summary panel with host statistics, aggregate counts, and TTL display.
 - Sort and filter results by failures, streaks, latency, or host name.
@@ -32,13 +32,13 @@ MultiPing is an interactive, terminal-based ICMP monitor that pings many hosts i
 
 ## Requirements
 - Python 3.9 or newer.
-- `scapy` (see `requirements.txt`).
-- Root/administrator privileges to send ICMP packets.
+- The `ping_helper` binary built with `cap_net_raw` (Linux) to run without `sudo`.
+- Root/administrator privileges if you cannot use the helper (non-Linux platforms).
 - Network access for optional ASN lookups.
 
-### Linux-Specific: Privileged ICMP Helper (Optional)
+### Linux-Specific: Privileged ICMP Helper (Recommended)
 
-On Linux, you can use the included `ping_helper` binary with capability-based privileges instead of running Python as root. This is more secure as it limits raw socket access to a single small binary.
+On Linux, use the included `ping_helper` binary with capability-based privileges instead of running Python as root. This is more secure as it limits raw socket access to a single small binary.
 
 **Dependencies:**
 - `gcc` (for building the helper)
@@ -71,7 +71,7 @@ git clone https://github.com/icecake0141/multiping.git
 cd multiping
 python -m pip install -r requirements.txt
 
-# Optional: Build the privileged ICMP helper (Linux only)
+# Build the privileged ICMP helper (Linux only)
 make build
 sudo make setcap
 ```
@@ -102,6 +102,7 @@ python main.py -t 2 -f hosts.txt
 - `--snapshot-timezone`: Timezone for snapshot filenames (`utc|display`).
 - `--flash-on-fail`: Flash screen (invert colors) when a ping fails to draw attention.
 - `--bell-on-fail`: Ring terminal bell when a ping fails to draw attention.
+- `--ping-helper`: Path to the `ping_helper` binary (default: `./ping_helper`).
 
 ### Interactive Controls
 - `n`: Cycle display name mode (ip/rdns/alias).

--- a/ping_helper.c
+++ b/ping_helper.c
@@ -124,6 +124,7 @@ int main(int argc, char *argv[]) {
     unsigned short expected_id = getpid() & 0xFFFF;
     unsigned short expected_seq = 1;
     uint32_t expected_addr = dest_addr->sin_addr.s_addr;
+    int reply_ttl = -1;
 
     /* Loop until we receive a matching reply or timeout */
     while (1) {
@@ -232,6 +233,7 @@ int main(int argc, char *argv[]) {
 
         /* This is our matching reply! Record end time and break */
         gettimeofday(&end_time, NULL);
+        reply_ttl = ip_hdr->ip_ttl;
         break;
     }
 
@@ -240,7 +242,7 @@ int main(int argc, char *argv[]) {
                     (end_time.tv_usec - start_time.tv_usec) / 1000.0;
 
     /* Output result */
-    printf("rtt_ms=%.3f\n", rtt_ms);
+    printf("rtt_ms=%.3f ttl=%d\n", rtt_ms, reply_ttl);
 
     close(sockfd);
     freeaddrinfo(res);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,14 @@
-scapy>=2.4.5
+# Copyright 2025 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+# Runtime dependencies for MultiPing.
+# (No external Python packages required.)


### PR DESCRIPTION
### Motivation
- Replace the Scapy-based raw-socket pings with a small setcap-enabled helper so the Python process does not require `sudo` to send ICMP requests. 
- Capture TTL from replies and expose it to the UI for better troubleshooting information. 
- Add a CLI option to configure the helper path and guard against the helper being missing at runtime. 

### Description
- Switch ping execution to the capability-based helper by importing `ping_with_helper` and invoking it from `ping_host`, and add `--ping-helper` CLI option to select the helper path. 
- Extend the helper and wrapper to emit and parse `ttl` alongside `rtt_ms`, and update `ping_helper.c` output formatting and `ping_wrapper.py` parsing accordingly. 
- Update unit tests to mock `ping_with_helper` and helper existence, and refresh documentation and `requirements.txt` to reflect the helper-based usage. 
- Files modified/created by the LLM: `main.py`, `ping_helper.c`, `ping_wrapper.py`, `tests/test_main.py`, `README.md`, `README.ja.md`, `requirements.txt` (please review these changes for correctness, security, and licensing). 

### Testing
- Ran `pytest`, which completed successfully with all tests passing (`75 passed`). 
- Validation commands used: `pytest`; attempted `python -m pip install -r requirements-dev.txt` and `python -m pylint main.py ping_wrapper.py tests/test_main.py` for linting but these failed due to environment/network (pylint not installed and pip blocked). 
- All unit tests updated for helper-based behavior and executed under `pytest` with the updated mocks and helper-path arguments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964664a91c4833086c517c394d166d2)