### PR TITLE
Validate timeout inputs in CLI and ping wrapper

### DIFF
--- a/main.py
+++ b/main.py
@@ -1121,6 +1121,9 @@ def main(args):
     if args.count < 0:
         print("Error: Count must be a non-negative number (0 for infinite).")
         return
+    if args.timeout <= 0:
+        print("Error: Timeout must be a positive number of seconds.")
+        return
 
     # Validate interval parameter
     if args.interval < 0.1 or args.interval > 60.0:

--- a/ping_wrapper.py
+++ b/ping_wrapper.py
@@ -41,6 +41,9 @@ def ping_with_helper(host, timeout_ms=1000, helper_path="./ping_helper"):
     Raises:
         FileNotFoundError: If the ping_helper binary is not found
     """
+    if timeout_ms <= 0:
+        raise ValueError("timeout_ms must be a positive integer in milliseconds.")
+
     if not os.path.exists(helper_path):
         raise FileNotFoundError(
             f"ping_helper binary not found at {helper_path}. "
@@ -114,6 +117,9 @@ def main():
             timeout_ms = int(sys.argv[2])
         except ValueError:
             print("Error: timeout_ms must be an integer", file=sys.stderr)
+            sys.exit(1)
+        if timeout_ms <= 0:
+            print("Error: timeout_ms must be a positive integer", file=sys.stderr)
             sys.exit(1)
 
     try:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -301,6 +301,27 @@ class TestMain(unittest.TestCase):
         mock_print.assert_called()
 
     @patch("builtins.print")
+    def test_main_with_invalid_timeout(self, mock_print):
+        """Test main function with invalid timeout"""
+        args = argparse.Namespace(
+            timeout=0,
+            count=4,
+            interval=1.0,
+            verbose=False,
+            hosts=["host1.com"],
+            input=None,
+            pause_mode="display",
+            timezone=None,
+            snapshot_timezone="utc",
+            ping_helper="./ping_helper",
+        )
+
+        main(args)
+        mock_print.assert_called()
+        call_args = [str(call) for call in mock_print.call_args_list]
+        self.assertTrue(any("Timeout" in str(call) for call in call_args))
+
+    @patch("builtins.print")
     def test_main_with_no_hosts(self, mock_print):
         """Test main function with no hosts"""
         args = argparse.Namespace(

--- a/tests/test_ping_wrapper.py
+++ b/tests/test_ping_wrapper.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# Copyright 2025 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+"""Unit tests for ping_wrapper."""
+
+import io
+import unittest
+from unittest.mock import patch
+
+import ping_wrapper
+
+
+class TestPingWrapper(unittest.TestCase):
+    """Tests for ping_wrapper behaviors."""
+
+    def test_ping_with_helper_rejects_non_positive_timeout(self):
+        """Ensure ping_with_helper rejects non-positive timeouts."""
+        with self.assertRaises(ValueError):
+            ping_wrapper.ping_with_helper("example.com", timeout_ms=0)
+
+    def test_main_rejects_non_positive_timeout(self):
+        """Ensure CLI rejects non-positive timeout."""
+        stderr = io.StringIO()
+        with patch("sys.argv", ["ping_wrapper.py", "example.com", "0"]):
+            with patch("sys.stderr", stderr):
+                with self.assertRaises(SystemExit) as exc:
+                    ping_wrapper.main()
+        self.assertEqual(exc.exception.code, 1)
+        self.assertIn("timeout_ms must be a positive integer", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Prevent non-positive timeout values from being accepted so callers and users receive clear feedback instead of undefined behavior or silent failures.
- Ensure both the high-level CLI (`main.py`) and the low-level wrapper (`ping_wrapper.py`) enforce consistent input validation for timeouts.  
- Add unit tests to exercise the new validation and keep behavior covered by automated tests.

### Description

- Add a check in `main.py` to reject `args.timeout <= 0` with a clear error message printed to the user.  
- Add validation in `ping_wrapper.py` so `ping_with_helper()` raises `ValueError` for `timeout_ms <= 0` and the `main()` CLI prints an error and exits when a non-positive `timeout_ms` is provided.  
- Update `tests/test_main.py` with a test for invalid timeout handling and add a new `tests/test_ping_wrapper.py` file covering the wrapper validation.  
- Files modified/created: `main.py`, `ping_wrapper.py`, `tests/test_main.py`, `tests/test_ping_wrapper.py` (modified/added by the LLM; please perform human review for correctness and security). 

### Testing

- Ran `pytest -q` which completed successfully with `78 passed` (command used: `pytest -q`).
- Attempted linting with `flake8` but the command was not available in the environment (command used: `flake8`).
- Attempted static analysis with `pylint` via `pylint main.py ping_wrapper.py tests/test_main.py tests/test_ping_wrapper.py` but the command was not available in the environment (command used: `pylint main.py ping_wrapper.py tests/test_main.py tests/test_ping_wrapper.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696477b6e6948330aad774594e336224)