### PR TITLE
docs: clarify IPv4-only support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ MultiPing is an interactive, terminal-based ICMP monitor that pings many hosts i
 - The `ping_helper` binary built with `cap_net_raw` (Linux) to run without `sudo`.
 - Root/administrator privileges if you cannot use the helper (non-Linux platforms).
 - Network access for optional ASN lookups.
+- IPv4-only support (hosts must resolve to IPv4 addresses).
 
 ### Linux-Specific: Privileged ICMP Helper (Recommended)
 
@@ -88,6 +89,10 @@ Example (with a host list file and 2-second timeout):
 ```bash
 python main.py -t 2 -f hosts.txt
 ```
+Example (explicit IPv4 addresses only):
+```bash
+python main.py 1.1.1.1 8.8.8.8
+```
 
 ### Command-line Options
 - `-t`, `--timeout`: Timeout in seconds for each ping (default: 1).
@@ -124,6 +129,7 @@ python main.py -t 2 -f hosts.txt
 ## Notes
 - ICMP requires elevated privileges (run with `sudo` or Administrator on Windows).
 - ASN lookups use `whois.cymru.com`; blocked networks will show blank ASN values.
+- IPv6 is not supported; use IPv4 addresses or hostnames that resolve to IPv4.
 
 ## License
 Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
### Motivation
- Make the current IPv4-only behavior explicit so users know hosts must resolve to IPv4 and avoid confusion or incorrect usage.
- Provide a short explicit example showing IPv4-only invocation to reduce support friction.

### Description
- Update `README.md` to declare "IPv4-only support (hosts must resolve to IPv4 addresses)" in Requirements and to add an IPv4-only usage example (`python main.py 1.1.1.1 8.8.8.8`).
- The modified file is `README.md`; this file already contains the project license header and an LLM-attribution header as required by project policy.
- LLM involvement: `README.md` was modified with LLM assistance; human review is pending and should verify wording and licensing notes.

### Testing
- Ran the unit test suite with `python -m pytest` and all tests passed (`75 passed` in the workspace run).
- Attempted dependency installation with `python -m pip install -r requirements-dev.txt` which failed due to a network/proxy error when fetching `pytest-cov`.
- Attempted linters/validation with `flake8 .`, `pylint --version`, and `pre-commit run --all-files`, but those commands were not available in the environment (command not found).
- Commit created with message `docs: clarify IPv4-only support` and the change is present in the working branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696477bd585c83309527b8f459a3d5a9)