### PR TITLE
Guard flash and bell on non-TTY output

### DIFF
--- a/main.py
+++ b/main.py
@@ -1047,6 +1047,8 @@ def read_key():
 
 def flash_screen():
     """Flash the screen by inverting colors for ~100ms"""
+    if not sys.stdout.isatty():
+        return
     # ANSI escape sequences for visual flash effect
     SAVE_CURSOR = "\x1b7"           # Save cursor position
     INVERT_COLORS = "\x1b[7m"       # Invert colors (white bg, black fg)
@@ -1067,6 +1069,8 @@ def flash_screen():
 
 def ring_bell():
     """Ring the terminal bell"""
+    if not sys.stdout.isatty():
+        return
     sys.stdout.write("\a")
     sys.stdout.flush()
 


### PR DESCRIPTION
### Motivation
- Avoid emitting terminal control sequences when `stdout` is not attached to a terminal.  
- Prevent flash/bell output from polluting logs or piped output in non-interactive runs.  
- Improve robustness of the TUI behavior when run in CI, redirected output, or other non-tty contexts.

### Description
- Add a TTY guard `if not sys.stdout.isatty(): return` at the start of `flash_screen()` and `ring_bell()` in `main.py`.  
- No other functional changes; flash and bell remain enabled for interactive terminals only.  
- Modified files: `main.py` (this file was created or modified with the assistance of an AI; please review for correctness and security).

### Testing
- Ran `python -m pytest` and the test suite passed with `75 passed`.  
- Tests completed successfully (test run reported ~11.57s total runtime).  
- No other automated test changes were required for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696477bbf28883308cc42e13b3bfd9c8)