### PR TITLE
Validate timeout_ms parsing and bounds

### DIFF
--- a/ping_helper.c
+++ b/ping_helper.c
@@ -54,12 +54,27 @@ int main(int argc, char *argv[]) {
     }
 
     const char *host = argv[1];
-    int timeout_ms = atoi(argv[2]);
-    
-    if (timeout_ms <= 0) {
+    const char *timeout_arg = argv[2];
+    char *endptr = NULL;
+    errno = 0;
+    long timeout_value = strtol(timeout_arg, &endptr, 10);
+    if (endptr == timeout_arg || *endptr != '\0') {
+        fprintf(stderr, "Error: timeout_ms must be an integer value\n");
+        return 2;
+    }
+    if (errno == ERANGE) {
+        fprintf(stderr, "Error: timeout_ms is out of range\n");
+        return 2;
+    }
+    if (timeout_value <= 0) {
         fprintf(stderr, "Error: timeout_ms must be positive\n");
         return 2;
     }
+    if (timeout_value > 60000) {
+        fprintf(stderr, "Error: timeout_ms must be 60000ms or less\n");
+        return 2;
+    }
+    int timeout_ms = (int)timeout_value;
 
     /* Resolve hostname */
     struct addrinfo hints, *res;


### PR DESCRIPTION
### Motivation
- Replace the unsafe `atoi` usage to detect conversion failures and prevent silent wrong values.
- Provide clear `stderr` error messages and non-zero exit codes when `timeout_ms` is invalid.
- Enforce a reasonable upper bound (60000ms) to avoid unintended long timeouts.

### Description
- Replace `atoi(argv[2])` with `strtol` and validate `endptr` and `errno` before casting to `int` in `ping_helper.c`.
- Add checks that the parsed value is positive and `<= 60000`, printing specific `stderr` messages and returning exit code `2` on failure.
- Preserve the file header and LLM attribution; modified file: `ping_helper.c` (this file was modified with the assistance of an LLM and has not yet had human review).

### Testing
- Ran `make build` successfully which produced the `ping_helper` binary.
- Ran `pytest -q` and the test suite passed with `75 passed in 11.49s`.
- Validation commands used: `make build` and `pytest -q`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696477c0429c833081849b9db7ca4fce)