### PR TITLE
Add hotkey to toggle summary panel (w)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -112,6 +112,7 @@ python main.py -t 2 -f hosts.txt
 - `o`: ソート切替（failures/streak/latency/host）。
 - `f`: フィルタ切替（failures/latency/all）。
 - `a`: ASN 表示の切替（スペース不足時は自動的に非表示）。
+- `w`: サマリーパネルの表示切替。
 - `p`: 一時停止/再開（表示のみ or ping + 表示）。
 - `s`: `multiping_snapshot_YYYYMMDD_HHMMSS.txt` を保存。
 - `←` / `→`: 時間を遡る/進める（最大30分前まで監視履歴を表示可能）。

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ python main.py 1.1.1.1 8.8.8.8
 - `o`: Cycle sort (failures/streak/latency/host).
 - `f`: Cycle filter (failures/latency/all).
 - `a`: Toggle ASN display (auto hides when space is tight).
+- `w`: Toggle the summary panel on/off.
 - `p`: Pause/resume (display only or ping + display).
 - `s`: Save a snapshot to `multiping_snapshot_YYYYMMDD_HHMMSS.txt`.
 - `←` / `→`: Navigate backward/forward in time (view monitoring history up to 30 minutes).

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,6 +50,7 @@ from main import (
     read_key,
     create_state_snapshot,
     latest_ttl_value,
+    toggle_panel_visibility,
 )  # noqa: E402
 
 
@@ -853,6 +854,26 @@ class TestStatusLine(unittest.TestCase):
         result = build_status_line("latency", "failures", False, None)
         self.assertIn("Latest Latency", result)
         self.assertIn("Failures Only", result)
+
+
+class TestPanelToggle(unittest.TestCase):
+    """Test summary panel toggle behavior"""
+
+    def test_toggle_hides_and_restores(self):
+        """Toggle hides panel and restores previous position."""
+        position, last_visible = toggle_panel_visibility("right", None)
+        self.assertEqual(position, "none")
+        self.assertEqual(last_visible, "right")
+
+        position, last_visible = toggle_panel_visibility(position, last_visible)
+        self.assertEqual(position, "right")
+        self.assertEqual(last_visible, "right")
+
+    def test_toggle_defaults_when_no_previous(self):
+        """Toggle restores to default when no previous position exists."""
+        position, last_visible = toggle_panel_visibility("none", None, "bottom")
+        self.assertEqual(position, "bottom")
+        self.assertEqual(last_visible, "bottom")
 
 
 class TestQuitHotkey(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- Provide a keyboard shortcut to toggle the summary/statistics panel on and off to reduce on-screen clutter while monitoring.  
- When toggled back on, restore the panel to the last visible position so user layout preferences are preserved.

### Description
- Add `toggle_panel_visibility` helper in `main.py` and wire the `w` hotkey to toggle `panel_position` and `last_panel_position` in the main loop.  
- Use the runtime `panel_position` for rendering and snapshotting so the UI reflects the toggle immediately and snapshots match current view.  
- Update `render_help_view` and the English/Japanese READMEs to document the `w` shortcut, and add unit tests in `tests/test_main.py` (`TestPanelToggle`) to validate toggle behavior.  
- LLM involvement: the following files were modified with LLM assistance: `main.py`, `tests/test_main.py`, `README.md`, `README.ja.md`; human review was performed to verify logic and tests.

### Testing
- Ran `python -m pytest` and all tests passed (80 passed).  
- Ran `python -m flake8` but the module is not available in the environment so linting could not be completed.  
- Ran `python -m pylint main.py tests/test_main.py` but the module is not available in the environment so static analysis could not be completed.  
- Attempted `pre-commit run --all-files` but `pre-commit` is not installed in the environment so hooks were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964a4a51da48330b6c8ac9089093c68)