### PR TITLE
Add summary-mode cycling for summary panel (hotkey 'm')

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -112,6 +112,7 @@ python main.py -t 2 -f hosts.txt
 - `o`: ソート切替（failures/streak/latency/host）。
 - `f`: フィルタ切替（failures/latency/all）。
 - `a`: ASN 表示の切替（スペース不足時は自動的に非表示）。
+- `m`: サマリー表示内容の切替（成功率/平均 RTT/TTL/連続回数）。
 - `w`: サマリーパネルの表示切替。
 - `p`: 一時停止/再開（表示のみ or ping + 表示）。
 - `s`: `multiping_snapshot_YYYYMMDD_HHMMSS.txt` を保存。

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ python main.py 1.1.1.1 8.8.8.8
 - `o`: Cycle sort (failures/streak/latency/host).
 - `f`: Cycle filter (failures/latency/all).
 - `a`: Toggle ASN display (auto hides when space is tight).
+- `m`: Cycle summary info (rates/avg RTT/TTL/streak).
 - `w`: Toggle the summary panel on/off.
 - `p`: Pause/resume (display only or ping + display).
 - `s`: Save a snapshot to `multiping_snapshot_YYYYMMDD_HHMMSS.txt`.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -661,7 +661,7 @@ class TestSummaryData(unittest.TestCase):
 
         width = 40
         height = 10
-        lines = render_summary_view(summary_data, width, height)
+        lines = render_summary_view(summary_data, width, height, "rates")
 
         # All lines should be exactly 'width' characters
         for line in lines:
@@ -686,7 +686,7 @@ class TestSummaryData(unittest.TestCase):
         # Use a reasonable width that can fit the status info
         width = 50
         height = 10
-        lines = render_summary_view(summary_data, width, height)
+        lines = render_summary_view(summary_data, width, height, "rates")
 
         # Check all lines fit within width
         for line in lines:
@@ -720,7 +720,7 @@ class TestSummaryData(unittest.TestCase):
 
         width = 35
         height = 20
-        lines = render_summary_view(summary_data, width, height)
+        lines = render_summary_view(summary_data, width, height, "rates")
 
         # All lines should fit within width
         for line in lines:
@@ -834,24 +834,24 @@ class TestStatusLine(unittest.TestCase):
 
     def test_build_status_line_basic(self):
         """Test basic status line building"""
-        result = build_status_line("failures", "all", False, None)
+        result = build_status_line("failures", "all", "rates", False, None)
         self.assertIn("Failure Count", result)
         self.assertIn("All Items", result)
         self.assertNotIn("PAUSED", result)
 
     def test_build_status_line_paused(self):
         """Test status line when paused"""
-        result = build_status_line("host", "all", True, None)
+        result = build_status_line("host", "all", "rates", True, None)
         self.assertIn("PAUSED", result)
 
     def test_build_status_line_with_message(self):
         """Test status line with custom message"""
-        result = build_status_line("failures", "all", False, "Test message")
+        result = build_status_line("failures", "all", "rates", False, "Test message")
         self.assertIn("Test message", result)
 
     def test_build_status_line_different_modes(self):
         """Test status line with different sort and filter modes"""
-        result = build_status_line("latency", "failures", False, None)
+        result = build_status_line("latency", "failures", "rates", False, None)
         self.assertIn("Latest Latency", result)
         self.assertIn("Failures Only", result)
 
@@ -1409,12 +1409,11 @@ class TestTTLFunctionality(unittest.TestCase):
 
         width = 50
         height = 10
-        lines = render_summary_view(summary_data, width, height)
+        lines = render_summary_view(summary_data, width, height, "ttl")
 
-        # Find the rtt line which should now include TTL
+        # Ensure TTL is shown in TTL mode
         combined = "\n".join(lines)
         self.assertIn("ttl 64", combined)
-        self.assertIn("avg rtt", combined)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- The summary panel contained too much information per host and lines wrapped, reducing readability.  
- Showing a single metric at a time and allowing the operator to cycle metrics with a hotkey keeps the panel compact while preserving access to all metrics.

### Description
- Add a `summary_mode` feature with modes `rates`, `rtt`, `ttl`, and `streak`, implement `format_summary_line` and update `render_summary_view` to render one metric per host.  
- Add hotkey `m` and propagate `summary_mode` through `build_display_lines`, `render_display`, `build_status_line`, and the main input loop so the active mode is shown in the status line and used for snapshots.  
- Update help text and documentation to list the `m` key and update tests to exercise the new API and modes.  
- Files modified by the LLM: `main.py`, `tests/test_main.py`, `README.md`, `README.ja.md`; human review: basic review performed to align tests and help text with changes, further security/edge-case review recommended.

### Testing
- Ran `pytest` and all tests passed (`80 passed` in local run).  
- Attempted `flake8 .` but the command was not available in the environment (did not run).  
- Attempted `pylint main.py ping_wrapper.py` but the command was not available in the environment (did not run).  
- Validation commands used: `pytest`, `flake8 .`, `pylint main.py ping_wrapper.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964aad4f6148330b406da7fdf4e256d)