### PR TITLE
Expand summary panel when positioned at top/bottom

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -128,6 +128,7 @@ python main.py -t 2 -f hosts.txt
 ## 補足
 - helper を使えない環境では ICMP を送信するため、`sudo` など管理者権限で実行してください。
 - ASN 取得は `whois.cymru.com` を使用します。アクセス不可の場合は空欄になります。
+- サマリーパネルを上/下に配置した場合、余白行を利用して表示行数を広げます。
 
 ## ライセンス
 Apache License 2.0。詳細は [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ python main.py 1.1.1.1 8.8.8.8
 - ICMP requires elevated privileges (run with `sudo` or Administrator on Windows).
 - ASN lookups use `whois.cymru.com`; blocked networks will show blank ASN values.
 - IPv6 is not supported; use IPv4 addresses or hostnames that resolve to IPv4.
+- When the summary panel is positioned at the top/bottom, it expands to use available empty rows.
 
 ## License
 Apache License 2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
### Motivation
- When the summary panel is placed at the bottom (or top), spare empty rows in the main area were not reallocated, causing the summary to be truncated even though space was available.
- Reallocate unused main-view rows to the summary panel so the summary always displays the maximum possible lines when positioned top/bottom.
- Preserve a reasonable minimum main view height while shifting any available rows to the summary area.
- Add a regression test and documentation to prevent future regressions and clarify behavior.

### Description
- Adjusted `build_display_lines` in `main.py` to compute a `min_main_height` and, when the summary panel is `top`/`bottom`, reduce the main view to a required height and increase `summary_height` by consuming unused rows.
- Added `test_bottom_panel_uses_extra_space` to `tests/test_main.py` to verify the summary expands into available empty rows and the overall terminal height is preserved.
- Updated `README.md` and `README.ja.md` to document that the summary panel expands to use available empty rows when positioned at the top/bottom.
- Files modified: `main.py`, `tests/test_main.py`, `README.md`, `README.ja.md`; this change was produced with LLM assistance and requires human review for correctness and security.

### Testing
- Ran `python -m pytest` which passed: 81 passed (example output: "81 passed in 11.24s").
- Attempted `flake8` (command: `flake8`) but the command was not available in the environment so linting was not executed.
- Attempted `pylint` (command: `pylint main.py`) but the command was not available in the environment so static analysis was not executed.
- Attempted to install dev requirements (`python -m pip install -r requirements-dev.txt`) but installation failed due to network/proxy errors, preventing further tooling runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964ae55a0008330bffa3001a744cd79)