### PR TITLE
Align ASN column in monitor display

### DIFF
--- a/main.py
+++ b/main.py
@@ -922,12 +922,15 @@ def resolve_display_name(host_info, mode):
     return host_info["ip"]
 
 
-def format_display_name(host_info, mode, include_asn, asn_width):
+def format_display_name(host_info, mode, include_asn, asn_width, base_label_width=0):
     base_label = resolve_display_name(host_info, mode)
     if not include_asn:
         return base_label
+    padded_label = (
+        f"{base_label:<{base_label_width}}" if base_label_width else base_label
+    )
     asn_label = format_asn_label(host_info, asn_width)
-    return f"{base_label} {asn_label}"
+    return f"{padded_label} {asn_label}"
 
 
 def format_asn_label(host_info, asn_width):
@@ -939,8 +942,15 @@ def format_asn_label(host_info, asn_width):
 
 
 def build_display_names(host_infos, mode, include_asn, asn_width):
+    base_label_width = 0
+    if include_asn:
+        base_label_width = max(
+            (len(resolve_display_name(info, mode)) for info in host_infos), default=0
+        )
     return {
-        info["id"]: format_display_name(info, mode, include_asn, asn_width)
+        info["id"]: format_display_name(
+            info, mode, include_asn, asn_width, base_label_width
+        )
         for info in host_infos
     }
 
@@ -1050,7 +1060,13 @@ def should_show_asn(
 ):
     if not show_asn:
         return False
-    labels = [format_display_name(info, mode, True, asn_width) for info in host_infos]
+    base_label_width = max(
+        (len(resolve_display_name(info, mode)) for info in host_infos), default=0
+    )
+    labels = [
+        format_display_name(info, mode, True, asn_width, base_label_width)
+        for info in host_infos
+    ]
     if not labels:
         return False
     label_width = max(len(label) for label in labels)


### PR DESCRIPTION
### Motivation
- Ensure ASN values start in the same column in the left panel so the ASN column is visually aligned across hosts.
- Currently varying lengths of IPs/aliases shift the ASN start column and make the display look jagged.
- Improve readability when ASN display is enabled without changing the displayed labels themselves.

### Description
- Pad the base display label to a common width before appending the ASN by extending `format_display_name` with a `base_label_width` parameter and using left-justification.
- Compute `base_label_width` in `build_display_names` and in `should_show_asn` when ASN display is enabled and pass it into `format_display_name` so labels and ASN align consistently.
- Modified files: `main.py`; LLM-modified files: `main.py`; human review: not yet performed.

### Testing
- Ran unit tests with `python -m pytest` which completed successfully: `80 passed`.
- Ran `flake8` (command not found in the environment) and therefore linting could not be validated here.
- Ran `pylint main.py` (command not found in the environment) and therefore static analysis could not be validated here.
- Validation commands used: `python -m pytest`, `flake8`, and `pylint main.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964af388f848330944c8eb9df4e7f10)