### PR TITLE
Fix: use white-background flash and disable flash in help view

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -105,7 +105,7 @@ python main.py -t 2 -f hosts.txt
 - `--pause-mode`: 一時停止の挙動（`display|ping`）。
 - `--timezone`: 表示時刻のタイムゾーン（IANA 名）。
 - `--snapshot-timezone`: スナップショット時刻のタイムゾーン（`utc|display`）。
-- `--flash-on-fail`: ping に失敗したときに画面をフラッシュ（色反転）して注意を惹く。
+- `--flash-on-fail`: ping に失敗したときに画面をフラッシュ（背景を白く）して注意を惹く。
 - `--bell-on-fail`: ping に失敗したときにターミナルベルを鳴らして注意を惹く。
 - `--color`: カラー表示を有効化（成功=青、遅延=黄、失敗=赤）。
 - `--ping-helper`: `ping_helper` バイナリのパス（デフォルト: `./ping_helper`）。

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ python main.py 1.1.1.1 8.8.8.8
 - `--pause-mode`: Pause behavior (`display|ping`).
 - `--timezone`: IANA timezone name for on-screen timestamps.
 - `--snapshot-timezone`: Timezone for snapshot filenames (`utc|display`).
-- `--flash-on-fail`: Flash screen (invert colors) when a ping fails to draw attention.
+- `--flash-on-fail`: Flash screen (white background) when a ping fails to draw attention.
 - `--bell-on-fail`: Ring terminal bell when a ping fails to draw attention.
 - `--color`: Enable colored output (blue=success, yellow=slow, red=fail).
 - `--ping-helper`: Path to the `ping_helper` binary (default: `./ping_helper`).

--- a/main.py
+++ b/main.py
@@ -273,7 +273,7 @@ def handle_options():
     parser.add_argument(
         "--flash-on-fail",
         action="store_true",
-        help="Flash screen (invert colors) when ping fails",
+        help="Flash screen (white background) when ping fails",
     )
     parser.add_argument(
         "--bell-on-fail",
@@ -1547,25 +1547,32 @@ def read_key():
 
 
 def flash_screen():
-    """Flash the screen by inverting colors for ~100ms"""
+    """Flash the screen with a white background for ~100ms"""
     if not sys.stdout.isatty():
         return
     # ANSI escape sequences for visual flash effect
     SAVE_CURSOR = "\x1b7"           # Save cursor position
-    INVERT_COLORS = "\x1b[7m"       # Invert colors (white bg, black fg)
+    SET_WHITE_BG = "\x1b[47m"       # White background
+    SET_BLACK_FG = "\x1b[30m"       # Black foreground
     CLEAR_SCREEN = "\x1b[2J"        # Clear screen
     MOVE_HOME = "\x1b[H"            # Move cursor to home position
-    RESTORE_COLORS = "\x1b[27m"     # Restore normal colors
     RESTORE_CURSOR = "\x1b8"        # Restore cursor position
     FLASH_DURATION_SECONDS = 0.1    # Duration of flash effect
 
-    # Apply inverted colors and clear screen
-    sys.stdout.write(SAVE_CURSOR + INVERT_COLORS + CLEAR_SCREEN + MOVE_HOME)
+    # Apply white flash effect and clear screen
+    sys.stdout.write(
+        SAVE_CURSOR + SET_WHITE_BG + SET_BLACK_FG + CLEAR_SCREEN + MOVE_HOME
+    )
     sys.stdout.flush()
     time.sleep(FLASH_DURATION_SECONDS)
     # Restore normal display
-    sys.stdout.write(RESTORE_COLORS + RESTORE_CURSOR)
+    sys.stdout.write(ANSI_RESET + RESTORE_CURSOR)
     sys.stdout.flush()
+
+
+def should_flash_on_fail(status, flash_on_fail, show_help):
+    """Return True when the failure flash should be displayed."""
+    return status == "fail" and flash_on_fail and not show_help
 
 
 def ring_bell():
@@ -2104,9 +2111,9 @@ def main(args):
                         stats[host_id]["rtt_count"] += 1
 
                     # Trigger flash or bell on ping failure
+                    if should_flash_on_fail(status, args.flash_on_fail, show_help):
+                        flash_screen()
                     if status == "fail":
-                        if args.flash_on_fail:
-                            flash_screen()
                         if args.bell_on_fail:
                             ring_bell()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -38,6 +38,7 @@ from main import (
     build_display_names,
     format_display_name,
     compute_summary_data,
+    should_flash_on_fail,
     render_summary_view,
     format_timestamp,
     format_timezone_label,
@@ -1496,6 +1497,9 @@ class TestFlashAndBell(unittest.TestCase):
         flash_screen()
         # Should have called write to send escape sequences
         self.assertGreaterEqual(mock_stdout.write.call_count, 2)
+        first_write = mock_stdout.write.call_args_list[0][0][0]
+        self.assertIn("\x1b[47m", first_write)
+        self.assertIn("\x1b[30m", first_write)
         # Should have slept for ~0.1 seconds
         mock_sleep.assert_called_once_with(0.1)
         # Should have called flush
@@ -1509,6 +1513,13 @@ class TestFlashAndBell(unittest.TestCase):
         mock_stdout.write.assert_called_once_with("\a")
         # Should flush the output
         mock_stdout.flush.assert_called_once()
+
+    def test_should_flash_on_fail(self):
+        """Test helper for flash-on-fail decision"""
+        self.assertTrue(should_flash_on_fail("fail", True, False))
+        self.assertFalse(should_flash_on_fail("fail", True, True))
+        self.assertFalse(should_flash_on_fail("success", True, False))
+        self.assertFalse(should_flash_on_fail("fail", False, False))
 
 
 class TestArrowKeyNavigation(unittest.TestCase):


### PR DESCRIPTION
### Motivation
- The existing failure flash used color inversion which produced an unintended darkening effect instead of a white flash.
- The flash also occurred while the help screen was visible, which is distracting and undesirable.

### Description
- Change `flash_screen()` to apply a white background (`\x1b[47m`) and black foreground (`\x1b[30m`) and restore display with `ANSI_RESET` instead of color inversion.
- Add `should_flash_on_fail(status, flash_on_fail, show_help)` and use it when processing ping results to skip flashing while `show_help` is active.
- Update option descriptions in `README.md` and `README.ja.md` to reflect the new white-background flash behavior. 
- Update `tests/test_main.py` to assert the white/black ANSI sequences and to add unit tests for the new helper function.

### Testing
- Ran unit tests with `python -m pytest` and all tests passed (`94 passed`).
- Attempted linting with `python -m flake8 main.py tests/test_main.py` and static checks with `python -m pylint main.py tests/test_main.py`, but these tools are not installed in the environment so linting was not completed. 
- Attempted to install dev dependencies with `python -m pip install -r requirements-dev.txt` but installation failed due to proxy restrictions (preventing `pytest-cov` download).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696616f05cf883309edb2217cafb6db1)