### PR TITLE
Use white for success color output

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -107,7 +107,7 @@ python main.py -t 2 -f hosts.txt
 - `--snapshot-timezone`: スナップショット時刻のタイムゾーン（`utc|display`）。
 - `--flash-on-fail`: ping に失敗したときに画面をフラッシュ（色反転）して注意を惹く。
 - `--bell-on-fail`: ping に失敗したときにターミナルベルを鳴らして注意を惹く。
-- `--color`: カラー表示を有効化（成功=青、遅延=黄、失敗=赤）。
+- `--color`: カラー表示を有効化（成功=白、遅延=黄、失敗=赤）。
 - `--ping-helper`: `ping_helper` バイナリのパス（デフォルト: `./ping_helper`）。
 
 ### 対話操作
@@ -130,7 +130,7 @@ python main.py -t 2 -f hosts.txt
 - `.` 成功
 - `!` 遅延（RTT >= `--slow-threshold`）
 - `x` 失敗/タイムアウト
-- `--color` 有効時: 成功=青、遅延=黄、失敗=赤
+- `--color` 有効時: 成功=白、遅延=黄、失敗=赤
 
 ## 補足
 - helper を使えない環境では ICMP を送信するため、`sudo` など管理者権限で実行してください。

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ python main.py 1.1.1.1 8.8.8.8
 - `--snapshot-timezone`: Timezone for snapshot filenames (`utc|display`).
 - `--flash-on-fail`: Flash screen (invert colors) when a ping fails to draw attention.
 - `--bell-on-fail`: Ring terminal bell when a ping fails to draw attention.
-- `--color`: Enable colored output (blue=success, yellow=slow, red=fail).
+- `--color`: Enable colored output (white=success, yellow=slow, red=fail).
 - `--ping-helper`: Path to the `ping_helper` binary (default: `./ping_helper`).
 
 ### Interactive Controls
@@ -135,7 +135,7 @@ python main.py 1.1.1.1 8.8.8.8
 - `.` success
 - `!` slow (RTT >= `--slow-threshold`)
 - `x` failure/timeout
-- When `--color` is enabled: blue=success, yellow=slow, red=failure.
+- When `--color` is enabled: white=success, yellow=slow, red=failure.
 
 ## Notes
 - ICMP requires elevated privileges (run with `sudo` or Administrator on Windows).

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ ACTIVITY_INDICATOR_SPEED_HZ = 4
 LAST_RENDER_LINES = None
 ANSI_RESET = "\x1b[0m"
 STATUS_COLORS = {
-    "success": "\x1b[34m",  # Blue
+    "success": "\x1b[37m",  # White
     "slow": "\x1b[33m",     # Yellow
     "fail": "\x1b[31m",     # Red
 }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1074,7 +1074,7 @@ class TestColorOutput(unittest.TestCase):
         symbols = {"success": ".", "fail": "x", "slow": "!"}
         timeline = [".", "!", "x"]
         colored = build_colored_timeline(timeline, symbols, use_color=True)
-        self.assertIn("\x1b[34m", colored)
+        self.assertIn("\x1b[37m", colored)
         self.assertIn("\x1b[33m", colored)
         self.assertIn("\x1b[31m", colored)
         self.assertIn("\x1b[0m", colored)
@@ -1087,7 +1087,7 @@ class TestColorOutput(unittest.TestCase):
         colored = build_colored_sparkline(
             sparkline, status_symbols, symbols, use_color=True
         )
-        self.assertIn("\x1b[34m", colored)
+        self.assertIn("\x1b[37m", colored)
         self.assertIn("\x1b[33m", colored)
         self.assertIn("\x1b[31m", colored)
 


### PR DESCRIPTION
### Motivation
- Success markers using blue were hard to read in some terminals, so use white for better contrast.
- Update user-facing documentation to reflect the color change.
- Keep tests aligned with the visible behavior when color output is enabled.

### Description
- Change the success ANSI color from blue to white in `main.py` by updating `STATUS_COLORS`.
- Update English and Japanese docs in `README.md` and `README.ja.md` to mention white for success when `--color` is enabled.
- Adjust tests in `tests/test_main.py` to expect the white ANSI code for success instead of blue.
- Files modified by the LLM: `main.py`, `tests/test_main.py`, `README.md`, `README.ja.md`; human review: not yet performed (please review for correctness and security).

### Testing
- Ran `pytest` and all tests passed (`93 passed`).
- Attempted `pip install -r requirements-dev.txt` but package installation failed due to network/proxy errors.
- Ran `flake8 .` and `pylint --version` validation commands were not available because linters could not be installed in this environment.
- Validation commands used: `pip install -r requirements-dev.txt`, `flake8 .`, `pylint --version`, and `pytest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966172b14908330bab039104840cb55)