### PR TITLE
Clear interactive UI on exit

### DIFF
--- a/main.py
+++ b/main.py
@@ -1639,6 +1639,14 @@ def update_history_buffer(
     return last_snapshot_time, history_offset
 
 
+def prepare_terminal_for_exit():
+    if not sys.stdout.isatty():
+        return
+    term_size = get_terminal_size(fallback=(80, 24))
+    sys.stdout.write("\n" * term_size.lines)
+    sys.stdout.flush()
+
+
 def main(args):
 
     # Validate count parameter - allow 0 for infinite
@@ -2192,6 +2200,7 @@ def main(args):
             if stdin_fd is not None and original_term is not None:
                 termios.tcsetattr(stdin_fd, termios.TCSADRAIN, original_term)
 
+    prepare_terminal_for_exit()
     print("\n" + "=" * 60)
     print("SUMMARY")
     print("=" * 60)


### PR DESCRIPTION
### Motivation
- The interactive renderer can leave ANSI-controlled status lines on the terminal when the process exits, making the final summary hard to read.
- The goal is to print the final results without emitting cursor-control escape sequences so the output is plain and readable after exit.

### Description
- Add a `prepare_terminal_for_exit()` helper that, when `stdout` is a TTY, scrolls the terminal by writing plain newlines equal to the terminal height and flushing `stdout`.
- Call `prepare_terminal_for_exit()` before printing the final summary to avoid leftover UI and avoid emitting escape sequences at exit.
- Modified file: `main.py` (LLM-assisted change; human review: pending).

### Testing
- Ran `pytest tests/ -v` which succeeded: `93 passed`.
- Attempted `python -m pip install -r requirements-dev.txt` but dependency installation failed due to network/proxy restrictions.
- Attempted `python -m pip install flake8 pylint` and `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` but lint tooling installation/execution failed due to network/proxy restrictions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966179414708330910c2e0c20070f8c)