### PR TITLE
Fix initial render cursor placement to avoid clipped header

### DIFF
--- a/main.py
+++ b/main.py
@@ -1281,7 +1281,11 @@ def render_display(
         return
 
     if LAST_RENDER_LINES is None:
-        sys.stdout.write("\x1b[2J\x1b[H" + "\n".join(combined_lines))
+        sys.stdout.write("\x1b[2J\x1b[H")
+        output_chunks = []
+        for index, line in enumerate(combined_lines):
+            output_chunks.append(f"\x1b[{index + 1};1H\x1b[2K{line}")
+        sys.stdout.write("".join(output_chunks))
         sys.stdout.flush()
         LAST_RENDER_LINES = combined_lines
         return


### PR DESCRIPTION
### Motivation
- Some terminals clip or misplace the first line when the initial render is written as a single newline-separated block, causing the top of the UI to appear truncated.  
- Align the initial render path with the incremental update path that uses explicit cursor positioning to ensure consistent layout.  
- Improve robustness of first-screen drawing so headers and status lines are not lost on certain terminal environments.  

### Description
- Change initial render in `render_display` to clear the screen then emit per-line cursor-positioning sequences instead of a single `"\n"`-joined block.  
- Build an `output_chunks` list for the initial render and write it with explicit `\x1b[{line};1H\x1b[2K{line}` sequences before flushing and setting `LAST_RENDER_LINES`.  
- File modified: `main.py` (LLM-assisted change; please review for correctness and terminal compatibility).  

### Testing
- Ran `pytest` which executed the test suite and reported `93 passed` (all tests passed).  
- Attempted dependency install with `python -m pip install -r requirements-dev.txt` but fetching `pytest-cov` failed due to a network/proxy restriction.  
- Lint/format/static checks attempted with `flake8 .` and `pylint main.py ping_wrapper.py ping_helper.c` were not run because the tools were not available after the dependency install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696617ceeddc833084dd8fd0f661294c)