### PR TITLE
Add multiping entrypoint and update README usage

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -87,12 +87,12 @@ sudo make setcap
 ![MultiPing デモ](docs/images/usage-demo.gif)
 
 ```bash
-python main.py [options] <host1> <host2> ...
+./multiping [options] <host1> <host2> ...
 ```
 
 例（ホスト一覧ファイルと 2 秒タイムアウト）:
 ```bash
-python main.py -t 2 -f hosts.txt
+./multiping -t 2 -f hosts.txt
 ```
 
 ### コマンドラインオプション

--- a/README.md
+++ b/README.md
@@ -88,16 +88,16 @@ sudo make setcap
 ![MultiPing Demo](docs/images/usage-demo.gif)
 
 ```bash
-python main.py [options] <host1> <host2> ...
+./multiping [options] <host1> <host2> ...
 ```
 
 Example (with a host list file and 2-second timeout):
 ```bash
-python main.py -t 2 -f hosts.txt
+./multiping -t 2 -f hosts.txt
 ```
 Example (explicit IPv4 addresses only):
 ```bash
-python main.py 1.1.1.1 8.8.8.8
+./multiping 1.1.1.1 8.8.8.8
 ```
 
 ### Command-line Options

--- a/multiping
+++ b/multiping
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# Copyright 2025 icecake0141
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# This file was created or modified with the assistance of an AI (Large Language Model).
+# Review required for correctness, security, and licensing.
+
+from main import handle_options, main
+
+
+if __name__ == "__main__":
+    options = handle_options()
+    main(options)


### PR DESCRIPTION
### Motivation
- Allow users to run the tool directly as the `multiping` command instead of invoking `python main.py`.
- Make documentation examples consistent with the new executable entrypoint for both English and Japanese READMEs.

### Description
- Add an executable wrapper script `multiping` that imports `handle_options` and `main` from `main.py` and invokes them.
- Update usage examples in `README.md` and `README.ja.md` to reference `./multiping` instead of `python main.py`.
- The new `multiping` file includes the project license header and an LLM attribution comment as required by repository policy.
- Files modified/added by the LLM: `multiping`, `README.md`, `README.ja.md`, and a human review is requested to validate CLI behavior and wording.

### Testing
- Ran the full test suite with `python -m pytest`, which succeeded: `98 passed in 11.46s`.
- Attempted to install dev requirements with `python -m pip install -r requirements-dev.txt`, which failed due to proxy restrictions when fetching `pytest-cov`.
- Attempted linting with `python -m flake8` and `python -m pylint main.py ping_wrapper.py multiping`, both of which failed because the tools are not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696622c710cc8330ba6556ff251160ca)