### PR TITLE
Validate timeout and interval CLI options

### DIFF
--- a/main.py
+++ b/main.py
@@ -305,6 +305,10 @@ def handle_options():
     )
 
     args = parser.parse_args()
+    if args.timeout <= 0:
+        parser.error("--timeout must be a positive integer.")
+    if not 0.1 <= args.interval <= 60.0:
+        parser.error("--interval must be between 0.1 and 60.0 seconds.")
     return args
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -148,6 +148,21 @@ class TestHandleOptions(unittest.TestCase):
             self.assertTrue(args.color)
             self.assertEqual(args.ping_helper, "/tmp/ping_helper")
 
+    def test_interval_out_of_range(self):
+        """Test interval range enforcement."""
+        with patch("sys.argv", ["main.py", "-i", "0.01", "example.com"]):
+            with self.assertRaises(SystemExit):
+                handle_options()
+        with patch("sys.argv", ["main.py", "-i", "61", "example.com"]):
+            with self.assertRaises(SystemExit):
+                handle_options()
+
+    def test_timeout_must_be_positive(self):
+        """Test timeout validation."""
+        with patch("sys.argv", ["main.py", "-t", "0", "example.com"]):
+            with self.assertRaises(SystemExit):
+                handle_options()
+
 
 class TestReadInputFile(unittest.TestCase):
     """Test input file reading functionality"""


### PR DESCRIPTION
### Motivation
- Prevent invalid CLI inputs (non-positive `--timeout` or out-of-range `--interval`) from causing runtime errors or unexpected behavior.
- Fail fast during argument parsing so callers receive clear, actionable errors.

### Description
- Add validation in `handle_options()` to require `args.timeout > 0` and `0.1 <= args.interval <= 60.0` in `main.py`.
- Add unit tests in `tests/test_main.py` to assert `SystemExit` is raised for invalid `--interval` and non-positive `--timeout` values.
- Modified files: `main.py`, `tests/test_main.py`.

### Testing
- Ran `pytest` and all tests passed (`100 passed`).
- Attempted `python -m pip install -r requirements-dev.txt` but installation failed due to a network/proxy error (could not fetch `pytest-cov`).
- `flake8` and `pylint` checks were not executed because the tools were not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696627765dc88330b87a609e082fcaa5)