### PR TITLE
Fix arrow key handling in host selection

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -51,6 +51,7 @@ from main import (
     flash_screen,
     ring_bell,
     read_key,
+    parse_escape_sequence,
     create_state_snapshot,
     update_history_buffer,
     latest_ttl_value,
@@ -592,6 +593,31 @@ class TestAsciiGraph(unittest.TestCase):
         lines = render_host_selection_view(entries, 1, 20, 6, "ip")
         combined = "\n".join(lines)
         self.assertIn("> host2", combined)
+
+
+class TestEscapeSequenceParsing(unittest.TestCase):
+    """Test escape sequence parsing for arrow keys."""
+
+    def test_parse_escape_sequence_basic_arrows(self):
+        self.assertEqual(parse_escape_sequence("[A"), "arrow_up")
+        self.assertEqual(parse_escape_sequence("[B"), "arrow_down")
+        self.assertEqual(parse_escape_sequence("[C"), "arrow_right")
+        self.assertEqual(parse_escape_sequence("[D"), "arrow_left")
+
+    def test_parse_escape_sequence_application_cursor(self):
+        self.assertEqual(parse_escape_sequence("OA"), "arrow_up")
+        self.assertEqual(parse_escape_sequence("OB"), "arrow_down")
+        self.assertEqual(parse_escape_sequence("OC"), "arrow_right")
+        self.assertEqual(parse_escape_sequence("OD"), "arrow_left")
+
+    def test_parse_escape_sequence_extended_arrows(self):
+        self.assertEqual(parse_escape_sequence("[1;5A"), "arrow_up")
+        self.assertEqual(parse_escape_sequence("[1;5B"), "arrow_down")
+        self.assertEqual(parse_escape_sequence("[1;5C"), "arrow_right")
+        self.assertEqual(parse_escape_sequence("[1;5D"), "arrow_left")
+
+    def test_parse_escape_sequence_unknown(self):
+        self.assertIsNone(parse_escape_sequence("[Z"))
 
     def test_render_fullscreen_rtt_graph_contains_header(self):
         """Fullscreen RTT graph should include host label and RTT range."""


### PR DESCRIPTION
### Motivation
- The fullscreen ASCII host-selection view ignored arrow key presses because multi-byte escape sequences could arrive in partial reads and were not recognized, causing only the first host to be selectable.
- The change aims to robustly parse arrow-key escape sequences (including application-cursor and extended variants) so up/down navigation and Enter selection work reliably.

### Description
- Added a new `parse_escape_sequence` helper and rewrote `read_key` to accumulate escape bytes until an arrow terminator or a timeout, handling partial/extended sequences and returning `arrow_up`/`arrow_down`/`arrow_left`/`arrow_right` where appropriate (`main.py`).
- Added unit tests `TestEscapeSequenceParsing` covering basic, application-cursor, extended arrow sequences, and unknown sequences (`tests/test_main.py`).
- Files modified: `main.py`, `tests/test_main.py` (these files were created/modified with LLM assistance; review for correctness and security is required). 

### Testing
- Ran `pytest`, which succeeded: `110 passed`.
- Attempted to run validation/linting tools but they were not available or failed to install in the environment: `pip install -r requirements-dev.txt` failed due to proxy when fetching `pytest-cov`, `python -m flake8 main.py tests/test_main.py` failed because `flake8` is not installed, and `python -m pylint main.py tests/test_main.py` failed because `pylint` is not installed.
- Unit tests added for `parse_escape_sequence` passed as part of the test suite run with `pytest`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696723803b448330b04fe76abbfc55a7)