### PR TITLE
[codex] Add coding agent documentation

### DIFF
--- a/docs/agent/change-routes.md
+++ b/docs/agent/change-routes.md
@@ -1,0 +1,193 @@
+<!--
+Copyright 2026 icecake0141
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# Change Routes for Coding Agents
+
+Each route lists the shortest practical path from change intent to code and
+tests. Read the primary files first, then expand only if the behavior crosses a
+boundary.
+
+## Add or Change a CLI Option
+
+Primary files:
+
+- `paraping/cli_options.py`: flags, defaults, choices, boolean pairs, config key.
+- `paraping/cli.py`: parser wiring, runtime state initialization, save-current-settings behavior.
+- `paraping/config.py`: config load/save validation and default path behavior.
+- `docs/usage.md`: user-facing CLI documentation.
+
+Relevant tests:
+
+- `pytest tests/unit/test_cli.py -v`
+- `pytest tests/unit/test_config.py -v`
+- `pytest tests/unit/test_main_options.py -v`
+- `pytest tests/unit/test_docs_usage_sync.py -v`
+
+Notes:
+
+- Keep CLI/config/hotkey ownership aligned with `docs/cli_option_policy.md`.
+- Boolean options should remain documented as explicit positive/negative pairs.
+
+## Change Ping Scheduling or Intervals
+
+Primary files:
+
+- `paraping_v2/scheduler.py`: scheduling model and stagger behavior.
+- `paraping_v2/rate_limit.py`: global ping-rate validation.
+- `paraping/cli.py`: runtime interval hotkeys, scheduler integration, worker coordination.
+- `paraping_v2/constants.py`: shared runtime limits and timing constants.
+
+Relevant tests:
+
+- `pytest tests/unit/test_scheduler.py -v`
+- `pytest tests/unit/test_scheduler_integration.py -v`
+- `pytest tests/unit/test_rate_limit.py -v`
+- `pytest tests/unit/test_cli.py -v`
+
+Notes:
+
+- Preserve the global rate-limit contract unless the product behavior is being intentionally changed.
+- Interval hotkeys and startup interval validation must stay consistent.
+
+## Change Timeline, Event, or History Behavior
+
+Primary files:
+
+- `paraping_v2/domain.py`: event and host/stat data structures.
+- `paraping_v2/engine.py`: event application, pending sequence replacement, timeline resizing.
+- `paraping_v2/history.py`: snapshot creation and history buffer updates.
+- `paraping_v2/render_state.py`: live vs historical render-state selection.
+- `paraping_v2/legacy_adapter.py`: projection into the existing UI shape.
+
+Relevant tests:
+
+- `pytest tests/unit/test_v2_engine.py -v`
+- `pytest tests/unit/test_v2_history.py -v`
+- `pytest tests/unit/test_v2_render_state.py -v`
+- `pytest tests/unit/test_timeline_sync.py -v`
+- `pytest tests/unit/test_sequence_tracking_integration.py -v`
+
+Notes:
+
+- Do not reintroduce removed legacy history helpers on `main` or `paraping.core`.
+- If the v2 shape changes, check the legacy adapter and UI tests because rendering still consumes projected data.
+
+## Change Rendering or Layout
+
+Primary files:
+
+- `paraping/ui_render.py`: display entries, layout computation, panels, status box, graph rendering, ANSI output.
+- `paraping_v2/render_state.py`: render-source selection.
+- `paraping_v2/legacy_adapter.py`: data shape consumed by UI functions.
+- `paraping_v2/term_size.py`: terminal-size normalization and timeline-width extraction.
+
+Relevant tests:
+
+- `pytest tests/unit/test_main_rendering.py -v`
+- `pytest tests/unit/test_main_display.py -v`
+- `pytest tests/unit/test_main_layout.py -v`
+- `pytest tests/unit/test_v2_render_state.py -v`
+- `pytest tests/unit/test_v2_term_size.py -v`
+
+Notes:
+
+- Keep rendering functions free of network side effects.
+- Avoid line-number-sensitive assumptions in tests; assert rendered behavior and stable layout contracts.
+
+## Change Hotkeys
+
+Primary files:
+
+- `paraping/keymap.py`: key-to-action mappings, action metadata, help grouping.
+- `paraping/input_keys.py`: raw key and escape-sequence parsing.
+- `paraping/cli.py`: action handling and runtime state updates.
+- `paraping/ui_render.py`: help view rendering.
+- `docs/usage.md`: interactive key documentation.
+
+Relevant tests:
+
+- `pytest tests/unit/test_keymap.py -v`
+- `pytest tests/unit/test_input_keys.py -v`
+- `pytest tests/unit/test_main_interaction.py -v`
+- `pytest tests/unit/test_docs_usage_sync.py -v`
+
+Notes:
+
+- Add actions centrally in `keymap.py`; avoid scattering key literals through the CLI loop.
+- Update help text and usage docs when a user-visible key changes.
+
+## Change Host Parsing
+
+Primary files:
+
+- `paraping_v2/hosts.py`: current host-line parsing, host-info construction, duplicate handling, diagnostics.
+- `paraping/core.py`: compatibility wrappers for legacy helper names.
+- `paraping/cli.py`: input-file load/reload behavior and user-facing diagnostics.
+- `hosts.txt.sample`: example host file if syntax changes.
+
+Relevant tests:
+
+- `pytest tests/unit/test_v2_hosts.py -v`
+- `pytest tests/unit/test_core.py -v`
+- `pytest tests/integration/test_multi_host_integration.py -v`
+
+Notes:
+
+- Prefer changing v2 host parsing first, then keep `paraping.core` wrappers delegating to it.
+- If accepted input syntax changes, update usage docs and examples together.
+
+## Change Ping Execution or Native Helper Behavior
+
+Primary files:
+
+- `paraping/pinger.py`: worker behavior, rDNS integration, scheduler-driven ping calls.
+- `paraping/ping_wrapper.py`: native helper invocation, output parsing, error handling.
+- `src/native/ping_helper.c`: privileged ICMP implementation.
+- `src/native/README.md` and `docs/ping_helper.md`: native helper contract documentation.
+
+Relevant tests:
+
+- `pytest tests/unit/test_pinger.py -v`
+- `pytest tests/unit/test_ping_wrapper.py -v`
+- `pytest tests/contract/test_ping_helper_contract.py -v`
+- `pytest tests/integration/test_multi_host_integration.py -v`
+
+Notes:
+
+- Keep the C helper contract and Python parser in sync.
+- Security-sensitive native-helper changes should preserve validation, minimal privilege assumptions, and documented exit/error behavior.
+
+## Update Public Compatibility Exports
+
+Primary files:
+
+- `main.py`: `_LAZY_EXPORTS`, eager wrappers, `__all__`, and compatibility aliases.
+- `paraping/core.py`: selected legacy helper names that delegate to v2 modules.
+- `paraping/__init__.py`: package-level exports, if the package surface changes.
+- `docs/v2_migration_status.md`: compatibility policy if the public contract changes.
+
+Relevant tests:
+
+- `pytest tests/unit/test_main_public_api_surface.py -v`
+- `pytest tests/unit/test_main_test_usage_surface.py -v`
+- `pytest tests/unit/test_main_lazy_wrappers.py -v`
+- `pytest tests/unit/test_public_api_surface.py -v`
+- `pytest tests/unit/test_no_main_imports_in_package.py -v`
+- `pytest tests/unit/test_removed_legacy_symbol_imports.py -v`
+
+Notes:
+
+- New implementation code should not depend on `main.py`.
+- When adding a lazy export, keep `_LAZY_EXPORTS` and `__all__` consistent.
+- Removed legacy history APIs are intentionally guarded; do not restore them unless the compatibility policy changes.

--- a/docs/agent/code-map.md
+++ b/docs/agent/code-map.md
@@ -1,0 +1,85 @@
+<!--
+Copyright 2026 icecake0141
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# Code Map for Coding Agents
+
+Use this map to find the owner of a behavior before editing. Prefer current
+runtime modules over compatibility shims.
+
+## Runtime Flow
+
+```text
+paraping.cli
+  -> paraping.pinger / paraping.ping_wrapper
+  -> paraping_v2.engine.MonitorState
+  -> paraping_v2.history
+  -> paraping_v2.render_state
+  -> paraping_v2.legacy_adapter
+  -> paraping.ui_render
+```
+
+`paraping.cli` is the orchestrator. It wires command-line options, config,
+host loading, worker threads, v2 state, interactive key actions, terminal
+redraws, snapshots, and shutdown cleanup.
+
+## Subsystem Ownership
+
+| Subsystem | Primary files | Notes |
+| --- | --- | --- |
+| CLI entrypoint and runtime loop | `paraping/cli.py`, `paraping/__main__.py` | `pyproject.toml` exposes `paraping = "paraping.cli:main"`. |
+| CLI option definitions | `paraping/cli_options.py`, `paraping/cli.py` | Option specs centralize flags, defaults, choices, and config keys. |
+| Runtime config persistence | `paraping/config.py`, `paraping/cli.py` | Runtime settings saved from CLI state use config keys from option specs. |
+| v2 event/state engine | `paraping_v2/engine.py`, `paraping_v2/domain.py` | Owns timeline symbols, pending sequences, and aggregate counters. |
+| History snapshots | `paraping_v2/history.py` | Current history implementation. Do not reintroduce removed legacy history APIs. |
+| Render-state selection | `paraping_v2/render_state.py` | Chooses live vs historical v2 state for rendering. |
+| Legacy render projection | `paraping_v2/legacy_adapter.py` | Converts v2 state into the shape expected by current UI functions. |
+| Scheduler and rate limits | `paraping_v2/scheduler.py`, `paraping_v2/rate_limit.py` | Own ping timing and global rate validation. |
+| Sequence tracking | `paraping_v2/sequence_tracker.py`, `paraping/sequence_tracker.py` | v2 is the current runtime source; legacy package surface remains tested. |
+| Host parsing and host IDs | `paraping_v2/hosts.py`, `paraping/core.py` | `paraping.core` delegates compatibility helpers to v2 host parsing. |
+| Terminal size and history paging | `paraping_v2/term_size.py`, `paraping_v2/paging.py`, `paraping/core.py` | Compatibility wrappers remain in `paraping.core`. |
+| Terminal rendering and layout | `paraping/ui_render.py` | Owns display entries, layout sizing, panels, status lines, graphs, and ANSI output. |
+| Statistics formatting | `paraping/stats.py`, `paraping/ui_render.py` | `stats.py` computes summary data; rendering formats it. |
+| Hotkeys and input parsing | `paraping/keymap.py`, `paraping/input_keys.py`, `paraping/cli.py` | Key definitions are centralized in `keymap.py`; raw key reading is separate. |
+| Ping worker behavior | `paraping/pinger.py` | Owns worker ping flow, rDNS worker behavior, and scheduler-driven ping calls. |
+| Ping helper wrapper | `paraping/ping_wrapper.py` | Owns subprocess invocation and parsing for the native helper. |
+| Native ICMP helper | `src/native/ping_helper.c`, `src/native/Makefile` | Linux privileged helper; see `docs/ping_helper.md`. |
+| ASN lookup | `paraping/network_asn.py` | Team Cymru lookup, retry behavior, and ASN worker thread. |
+| Compatibility shim | `main.py` | Backward-compatible lazy exports for tests and external callers. |
+
+## Compatibility Boundaries
+
+- `main.py` is not the implementation target for new behavior. It should only
+  expose compatibility wrappers and lazy exports when a public compatibility
+  contract intentionally changes.
+- `main.__all__` is the compatibility contract for the shim. Keep
+  `_LAZY_EXPORTS`, eager wrappers, and `__all__` consistent.
+- `paraping.core` keeps selected legacy helper names and delegates current
+  behavior to `paraping_v2`. New runtime logic should usually live in v2 modules
+  or focused `paraping.*` modules, not in `paraping.core`.
+- Package code must not import from `main.py`. Guardrail tests enforce this.
+
+## Import Guidance
+
+- New current-runtime state, history, scheduler, host parsing, paging, and
+  terminal-size logic should import from `paraping_v2.*`.
+- CLI orchestration, rendering, ping execution, config, key handling, and
+  compatibility wrappers live under `paraping.*`.
+- Tests may import compatibility surfaces when explicitly validating them, but
+  new implementation code should use direct package modules.
+
+## Historical Docs
+
+Some older docs describe pre-v2 modularization and remain useful as background.
+For current runtime ownership, prefer this directory and
+[`../v2_migration_status.md`](../v2_migration_status.md).

--- a/docs/agent/index.md
+++ b/docs/agent/index.md
@@ -1,0 +1,61 @@
+<!--
+Copyright 2026 icecake0141
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# Coding Agent Guide
+
+This directory is the fastest starting point for coding agents working on ParaPing.
+It is organized by purpose: first understand which subsystem owns a behavior, then
+open the smallest set of files and tests needed for the change.
+
+## Current Source of Truth
+
+ParaPing is an interactive terminal ICMP monitor. The current runtime path is
+v2-based:
+
+1. `paraping.cli` coordinates CLI parsing, runtime state, workers, hotkeys, and rendering.
+2. Ping workers emit normalized events into `paraping_v2.engine.MonitorState`.
+3. History and render-source selection use `paraping_v2.history` and `paraping_v2.render_state`.
+4. Existing UI functions consume a legacy-shaped projection from `paraping_v2.legacy_adapter`.
+
+Treat `main.py` as a compatibility shim. New package code should import from
+`paraping.*` or `paraping_v2.*`, not from `main`.
+
+## Fast Navigation
+
+| Goal | Start here | Then check |
+| --- | --- | --- |
+| Add or change a CLI option | [change-routes.md](change-routes.md#add-or-change-a-cli-option) | `paraping/cli_options.py`, `paraping/cli.py`, `paraping/config.py` |
+| Change ping scheduling or intervals | [change-routes.md](change-routes.md#change-ping-scheduling-or-intervals) | `paraping_v2/scheduler.py`, `paraping_v2/rate_limit.py`, `paraping/cli.py` |
+| Change timeline, event, or history behavior | [change-routes.md](change-routes.md#change-timeline-event-or-history-behavior) | `paraping_v2/engine.py`, `paraping_v2/history.py`, `paraping_v2/render_state.py` |
+| Change terminal rendering or layout | [change-routes.md](change-routes.md#change-rendering-or-layout) | `paraping/ui_render.py`, `paraping_v2/render_state.py`, `paraping_v2/legacy_adapter.py` |
+| Change hotkeys or help text | [change-routes.md](change-routes.md#change-hotkeys) | `paraping/keymap.py`, `paraping/input_keys.py`, `paraping/ui_render.py` |
+| Change host-file parsing or host metadata | [change-routes.md](change-routes.md#change-host-parsing) | `paraping_v2/hosts.py`, `paraping/core.py` |
+| Change ping execution or native helper behavior | [change-routes.md](change-routes.md#change-ping-execution-or-native-helper-behavior) | `paraping/pinger.py`, `paraping/ping_wrapper.py`, `src/native/ping_helper.c` |
+| Update compatibility exports | [change-routes.md](change-routes.md#update-public-compatibility-exports) | `main.py`, `paraping/core.py`, compatibility tests |
+| Pick tests for a change | [testing-routes.md](testing-routes.md) | `docs/testing.md` |
+
+## Documents in This Directory
+
+- [Code Map](code-map.md): subsystem ownership and preferred files to inspect.
+- [Change Routes](change-routes.md): practical routes from change intent to code and tests.
+- [Testing Routes](testing-routes.md): targeted test commands and compatibility guardrails.
+
+## Canonical Project Docs
+
+- [Documentation Index](../index.md)
+- [Usage Guide](../usage.md)
+- [Testing Guide](../testing.md)
+- [v2 Migration Status](../v2_migration_status.md)
+- [Ping Helper](../ping_helper.md)
+- [Contributing](../CONTRIBUTING.md)

--- a/docs/agent/testing-routes.md
+++ b/docs/agent/testing-routes.md
@@ -1,0 +1,92 @@
+<!--
+Copyright 2026 icecake0141
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+This file was created or modified with the assistance of an AI (Large Language Model).
+Review required for correctness, security, and licensing.
+-->
+
+# Testing Routes for Coding Agents
+
+Use targeted tests while iterating, then run the broader checks needed for the
+change risk. The full testing guide remains in [`../testing.md`](../testing.md).
+
+## Quick Commands
+
+```bash
+# Default suite
+make test
+
+# Full pytest suite
+pytest tests/ -v
+
+# Coverage run
+pytest tests/ -v --cov=. --cov-report=term-missing --cov-report=xml
+```
+
+## Targeted Test Selection
+
+| Change area | Start with |
+| --- | --- |
+| CLI options and startup behavior | `pytest tests/unit/test_cli.py tests/unit/test_main_options.py -v` |
+| Runtime config | `pytest tests/unit/test_config.py -v` |
+| Scheduler and intervals | `pytest tests/unit/test_scheduler.py tests/unit/test_scheduler_integration.py tests/unit/test_rate_limit.py -v` |
+| v2 event engine | `pytest tests/unit/test_v2_engine.py -v` |
+| History and render-state resolution | `pytest tests/unit/test_v2_history.py tests/unit/test_v2_render_state.py tests/unit/test_timeline_sync.py -v` |
+| Host parsing | `pytest tests/unit/test_v2_hosts.py tests/unit/test_core.py -v` |
+| Rendering and layout | `pytest tests/unit/test_main_rendering.py tests/unit/test_main_display.py tests/unit/test_main_layout.py -v` |
+| Terminal sizing and paging | `pytest tests/unit/test_v2_term_size.py tests/unit/test_v2_paging.py tests/unit/test_core_term_size_normalization.py -v` |
+| Hotkeys and key input | `pytest tests/unit/test_keymap.py tests/unit/test_input_keys.py tests/unit/test_main_interaction.py -v` |
+| Ping worker and helper wrapper | `pytest tests/unit/test_pinger.py tests/unit/test_ping_wrapper.py -v` |
+| Native ping helper contract | `pytest tests/contract/test_ping_helper_contract.py -v` |
+| ASN lookup | `pytest tests/integration/test_network_asn.py -v` |
+| Documentation sync | `pytest tests/unit/test_docs_usage_sync.py -v` |
+
+## Compatibility Guardrails
+
+Run these when touching `main.py`, `paraping/core.py`, `paraping_v2`, public
+exports, or removed legacy APIs:
+
+```bash
+pytest \
+  tests/unit/test_main_public_api_surface.py \
+  tests/unit/test_main_test_usage_surface.py \
+  tests/unit/test_main_lazy_wrappers.py \
+  tests/unit/test_main_legacy_history_usage_contract.py \
+  tests/unit/test_cli_v2_no_legacy_history_refs.py \
+  tests/unit/test_legacy_api_usage_contract.py \
+  tests/unit/test_public_api_surface.py \
+  tests/unit/test_v2_legacy_module_removed.py \
+  tests/unit/test_no_main_imports_in_package.py \
+  tests/unit/test_removed_legacy_symbol_imports.py \
+  -v
+```
+
+These tests protect the current compatibility policy:
+
+- `main.__all__` defines the shim contract.
+- Lazy exports in `main._LAZY_EXPORTS` must stay consistent with `__all__`.
+- Package code must not import from `main.py`.
+- Removed legacy history APIs must remain absent unless the policy changes.
+
+## Pre-PR Checks
+
+Use the same checks documented in [`../testing.md`](../testing.md) and
+[`../CONTRIBUTING.md`](../CONTRIBUTING.md):
+
+```bash
+make lint
+flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+pylint . --fail-under=9.0
+mypy
+pytest tests/ -v --cov=. --cov-report=term-missing --cov-report=xml
+```
+
+For documentation-only changes, targeted documentation tests plus a Markdown
+link sanity check are usually enough unless CI policy requires the full suite.

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,6 +58,9 @@ Welcome to the ParaPing documentation hub. This directory contains comprehensive
 - [API Documentation](api/index.md) - Module layout and API reference (coming soon)
 - [Ping Helper Documentation](ping_helper.md) - Deep dive into the ICMP helper
 
+### For Coding Agents
+- [Coding Agent Guide](agent/index.md) - Purpose-structured routes for finding the right code and tests before making changes
+
 ## Repository Overview
 
 ParaPing is an interactive terminal-based ICMP monitor that pings multiple hosts in parallel with live visualization. Key features include:
@@ -133,6 +136,9 @@ ParaPingドキュメントハブへようこそ。このディレクトリには
 ### 開発者向け
 - [APIドキュメント](api/index.md) - モジュールレイアウトとAPIリファレンス（近日公開）
 - [Pingヘルパードキュメント](ping_helper.md) - ICMPヘルパーの詳細
+
+### コーディングエージェント向け
+- [Coding Agent Guide](agent/index.md) - 変更前に参照すべきコードとテストを目的別に整理した英語ドキュメント
 
 ## リポジトリ概要
 


### PR DESCRIPTION
## Summary
- Add an English coding-agent documentation entrypoint under `docs/agent/`.
- Add purpose-based code maps, change routes, and targeted testing routes for future agent work.
- Link the new guide from the existing documentation index.

## Impact
This gives coding agents a shorter path to understand the current v2 runtime ownership, compatibility boundaries, and relevant tests before making changes.

## Validation
- `pytest tests/unit/test_docs_usage_sync.py -v`
- Local Markdown link target sanity check for `docs/index.md` and `docs/agent/*.md`