### PR TITLE
[codex] limit pages artifact to tour

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,10 +44,15 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v6
 
-      - name: Upload static docs
+      - name: Build Pages artifact
+        run: |
+          mkdir -p _site
+          cp -R docs/tour _site/tour
+
+      - name: Upload tour site
         uses: actions/upload-pages-artifact@v4
         with:
-          path: docs
+          path: _site
 
       - name: Deploy
         id: deployment


### PR DESCRIPTION
## Summary
- Publish only the UX tour through GitHub Pages instead of uploading the full `docs/` directory.
- Build a minimal `_site/tour` artifact from `docs/tour` so the public URL remains `/paraping/tour/`.

## Why
The repository documentation under `docs/` does not all need to be part of the GitHub Pages artifact. This keeps the published surface focused on the user experience tour.

## Validation
- Parsed `.github/workflows/pages.yml` with PyYAML
- Confirmed the workflow contains `cp -R docs/tour _site/tour` and uploads `path: _site`
- Locally built the artifact shape and confirmed it contains only `tour/` files/assets